### PR TITLE
process.py: `--size` will also affect `edges`

### DIFF
--- a/tools/process.py
+++ b/tools/process.py
@@ -22,7 +22,7 @@ parser.add_argument("--operation", required=True, choices=["grayscale", "resize"
 parser.add_argument("--workers", type=int, default=1, help="number of workers")
 # resize
 parser.add_argument("--pad", action="store_true", help="pad instead of crop for resize operation")
-parser.add_argument("--size", type=int, default=256, help="size to use for resize operation")
+parser.add_argument("--size", type=int, default=256, help="size to use for resize and edges operations")
 # combine
 parser.add_argument("--b_dir", type=str, help="path to folder containing B images for combine operation")
 a = parser.parse_args()
@@ -172,7 +172,7 @@ imwrite(E, output_path);
         config = dict(
             input_path="'%s'" % mat_file.name,
             output_path="'%s'" % png_file.name,
-            image_width=256,
+            image_width=a.size,
             threshold=25.0/255.0,
             small_edge=5,
         )


### PR DESCRIPTION
Right now, the edges images are always 256*256.

As one might wish to use different sizes of images (and it's possible to specify output size for `resize` operation) it seems consistent to also be able to produce edges with desired size.