### PR TITLE
Adding the compatibility to Python3.5 for the process_local.py server file

### DIFF
--- a/server/tools/process-local.py
+++ b/server/tools/process-local.py
@@ -25,8 +25,8 @@ def main():
     with tf.Session() as sess:
         saver = tf.train.import_meta_graph(a.model_dir + "/export.meta")
         saver.restore(sess, a.model_dir + "/export")
-        input_vars = json.loads(tf.get_collection("inputs")[0])
-        output_vars = json.loads(tf.get_collection("outputs")[0])
+        input_vars = json.loads(tf.get_collection("inputs")[0].decode('utf8'))
+        output_vars = json.loads(tf.get_collection("outputs")[0].decode('utf8'))
         input = tf.get_default_graph().get_tensor_by_name(input_vars["input"])
         output = tf.get_default_graph().get_tensor_by_name(output_vars["output"])
 


### PR DESCRIPTION
Using the `server/tools/process_local.py` script with Python 3.5 throws an error as the `json.loads` function accepts binary data only from Python 3.6. [Culprit lines](
https://github.com/affinelayer/pix2pix-tensorflow/blob/d6f8e4ce00a1fd7a96a72ed17366bfcb207882c7/server/tools/process-local.py#L30-L31)

```
Traceback (most recent call last):
  File "server/tools/process-local.py", line 45, in <module>
    main()
  File "server/tools/process-local.py", line 28, in main
    input_vars = json.loads(tf.get_collection("inputs")[0])
  File "D:\Tools\Python35\lib\json\__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

To solve it, we can update the [Culprit lines](
https://github.com/affinelayer/pix2pix-tensorflow/blob/d6f8e4ce00a1fd7a96a72ed17366bfcb207882c7/server/tools/process-local.py#L30-L31) to:

```
input_vars = json.loads(tf.get_collection("inputs")[0].decode('utf8'))
output_vars = json.loads(tf.get_collection("outputs")[0].decode('utf8'))
```