### PR TITLE
Fixed bug with docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get install -y --no-install-recommends \
         cmake \
         git \
         wget \
+        curl \
         libatlas-base-dev \
         libboost-all-dev \
         libgflags-dev \


### PR DESCRIPTION
There was an error, during the building of nvidia-docker image from your file. Fixed by adding 'curl' to apt-get installation.

> Step 11/18 : RUN cd $CAFFE_ROOT && curl -O http://vcl.ucsd.edu/hed/hed_pretrained_bsds.caffemodel
>  ---> Running in f67e30aa75b9
> /bin/sh: 1: curl: not found
> The command '/bin/sh -c cd $CAFFE_ROOT && curl -O http://vcl.ucsd.edu/hed/hed_pretrained_bsds.caffemodel' returned a non-zero code: 127