### PR TITLE
Add options to train and export TFLite compatible models

### DIFF
--- a/pix2pix.py
+++ b/pix2pix.py
@@ -44,7 +44,7 @@ parser.add_argument("--lr", type=float, default=0.0002, help="initial learning r
 parser.add_argument("--beta1", type=float, default=0.5, help="momentum term of adam")
 parser.add_argument("--l1_weight", type=float, default=100.0, help="weight on L1 term for generator gradient")
 parser.add_argument("--gan_weight", type=float, default=1.0, help="weight on GAN term for generator gradient")
-parser.add_argument("--norm_type", default="default", choices=["none", "default", "original"])
+parser.add_argument("--norm_type", default="original", choices=["none", "original", "tflite_compatible"])
 
 # export options
 parser.add_argument("--output_filetype", default="png", choices=["png", "jpeg"])

--- a/tools/query-export.py
+++ b/tools/query-export.py
@@ -1,0 +1,76 @@
+import os
+import argparse
+from pprint import pprint
+
+import cv2
+import numpy as np
+import tensorflow as tf
+from tensorflow.python.platform import gfile
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--export", default=None, help="output_dir from --mode export run")
+    parser.add_argument("--frozen", default=None, help="frozen graph pb file")
+    parser.add_argument("--tflite", default=None, help="tflite file")
+    parser.add_argument("--input", default='Untitled.png', help="input image")
+    parser.add_argument("--output", default='out.png', help="output image")
+    a = parser.parse_args()
+
+    out_files = [ a.output ]
+    im_files = [ a.input ]
+    images_cv = [ cv2.resize(cv2.imread(f), (256, 256)) for f in im_files ]
+    images = np.array(images_cv, dtype=np.float32)
+    images = images / 255.0
+
+    if a.tflite:
+        interpreter = tf.lite.Interpreter(model_path=a.tflite)
+        interpreter.allocate_tensors()
+        input_details = interpreter.get_input_details()
+        output_details = interpreter.get_output_details()
+        print(input_details)
+        print(output_details)
+
+        interpreter.set_tensor(input_details[0]['index'], images)
+        interpreter.invoke()
+        output = interpreter.get_tensor(output_details[0]['index'])
+        output = output[:,:,:,::-1]
+        output = output * 255
+
+        print("Writing " + out_files[0])
+        cv2.imwrite(out_files[0], output[0]);
+
+    if a.frozen:
+        with tf.Session() as sess:
+            with gfile.FastGFile(a.frozen, 'rb') as f:
+                graph_def = tf.GraphDef()
+                graph_def.ParseFromString(f.read())
+                sess.graph.as_default()
+                tf.import_graph_def(graph_def, name='')
+
+            input = tf.get_default_graph().get_tensor_by_name("TFLiteInput:0")
+            output = tf.get_default_graph().get_tensor_by_name("TFLiteOutput:0")
+            output = output[:,:,:,::-1]
+            output = output * 255
+
+            print("Writing " + out_files[0])
+            cv2.imwrite(out_files[0], output.eval({'TFLiteInput:0': images})[0]);
+
+    if a.export:
+        with tf.Session() as sess:
+            with gfile.FastGFile(os.path.join(a.export, 'export.meta'), 'rb') as f:
+                meta_graph_def = tf.MetaGraphDef()
+                meta_graph_def.ParseFromString(f.read())
+                tf.train.import_meta_graph(meta_graph_def)
+                checkpoint = tf.train.latest_checkpoint(a.export)
+                restore_saver = tf.train.Saver()
+                restore_saver.restore(sess, checkpoint)
+
+            input = tf.get_default_graph().get_tensor_by_name("TFLiteInput:0")
+            output = tf.get_default_graph().get_tensor_by_name("TFLiteOutput:0")
+            output = output[:,:,:,::-1]
+            output = output * 255
+
+            print("Writing " + out_files[0])
+            cv2.imwrite(out_files[0], output.eval({'TFLiteInput:0': images})[0]);
+
+main()


### PR DESCRIPTION
These are the changes needed to get pix2pix-tensorflow running on mobile.

tf.layers.batch_normalization() on TFLite requires training=False, and that the model was trained with training=True and batch_size > 1.  Also TFLite has no tf.tanh(), tf.image.convert_image_dtype(), or others.

Updating the batch_normalization Tensorflow variables for training=False (which aren't trainable vars) requires the UPDATE_OPS dependencies.

I have to re-train the model using tf.contrib.layers.instance_norm() instead of tf.layers.batch_normalization() with batch_size=1.  It seems to work good.  Is it the exact same thing?

